### PR TITLE
Fixed an issue where the mdx plugin would get wrapped in undnefind tags.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,9 @@ module.exports = function gatsbyRemarkCodeTitles(_ref, pluginOptions) {
     const className = ["gatsby-code-title"].concat(customClassName || []);
     const titleNode = {
       type: "html",
-      value: `
-        <div class="${className.join(" ").trim()}">
+      value: `<div class="${className.join(" ").trim()}">
           <span>${title}</span>
-        </div>
-       `
+        </div>`
     };
 
     markdownAST.children.splice(index, 0, titleNode);


### PR DESCRIPTION
`gatsby-plugin-mdx` で当プラグインを使用すると、AST変換時に改行コードが `<undefind>` タグとしてラップされてしまうようなので、  
改行を消した対応だけですが、こちらの方で微修正しました。

気が向いたらで良いので、確認していただけると幸いです。

> When using this plugin with `gatsby-plugin-mdx`, it seems that line feeds are wrapped as `<undefind>` tags during AST conversion.  
> I made a minor fix here, though it's only a response to remove the newline.

### related issue
#2 